### PR TITLE
feat: add method to get validator registration

### DIFF
--- a/data/client.go
+++ b/data/client.go
@@ -80,11 +80,6 @@ func (c *TransparencyClient) GetProposerPayloadsDelivered(
 		return nil, err
 	}
 
-	// Handle error in the response.
-	if res.StatusCode >= 400 {
-		return nil, fmt.Errorf("failed request to %s with status code %d", url, res.StatusCode)
-	}
-
 	// Extract bid traces from response.
 	var traces []types.BidTrace
 	if err = json.NewDecoder(res.Body).Decode(&traces); err != nil {
@@ -92,4 +87,24 @@ func (c *TransparencyClient) GetProposerPayloadsDelivered(
 	}
 
 	return traces, nil
+}
+
+// GetValidatorRegistration returns the latest validator registration for a given public key.
+// Useful to check whether your own registration was successful.
+func (c *TransparencyClient) GetValidatorRegistration(publicKey types.
+	PublicKey) (*types.SignedValidatorRegistration, error) {
+	path := "/relay/v1/data/validator_registration"
+	url := c.baseURL + fmt.Sprintf("%s?pubkey=%s", path, publicKey.String())
+
+	res, err := http.Get(url) //nolint
+	if err != nil {
+		return nil, err
+	}
+
+	registration := &types.SignedValidatorRegistration{}
+	if err = json.NewDecoder(res.Body).Decode(registration); err != nil {
+		return nil, err
+	}
+
+	return registration, nil
 }

--- a/data/client.go
+++ b/data/client.go
@@ -80,6 +80,11 @@ func (c *TransparencyClient) GetProposerPayloadsDelivered(
 		return nil, err
 	}
 
+	// Handle error in the response.
+	if res.StatusCode >= 400 {
+		return nil, fmt.Errorf("failed request to %s with status code %d", url, res.StatusCode)
+	}
+
 	// Extract bid traces from response.
 	var traces []types.BidTrace
 	if err = json.NewDecoder(res.Body).Decode(&traces); err != nil {
@@ -101,10 +106,15 @@ func (c *TransparencyClient) GetValidatorRegistration(publicKey types.
 		return nil, err
 	}
 
-	registration := &types.SignedValidatorRegistration{}
-	if err = json.NewDecoder(res.Body).Decode(registration); err != nil {
+	// Handle error in the response.
+	if res.StatusCode >= 400 {
+		return nil, fmt.Errorf("failed request to %s with status code %d", url, res.StatusCode)
+	}
+
+	registration := types.SignedValidatorRegistration{}
+	if err = json.NewDecoder(res.Body).Decode(&registration); err != nil {
 		return nil, err
 	}
 
-	return registration, nil
+	return &registration, nil
 }

--- a/data/client_test.go
+++ b/data/client_test.go
@@ -98,10 +98,16 @@ func TestGetValidatorRegistration(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name:          "Validator",
+			name:          "Get valid validator registration",
 			baseURL:       constants.FlashbotsRelayMainnet,
 			publicKey:     publicKey,
 			expectedError: false,
+		},
+		{
+			name:          "Get invalid validator registration",
+			baseURL:       constants.FlashbotsRelayMainnet,
+			publicKey:     types.PublicKey{},
+			expectedError: true,
 		},
 	}
 

--- a/data/client_test.go
+++ b/data/client_test.go
@@ -2,7 +2,9 @@ package data
 
 import (
 	"github.com/0xpanoramix/frd-go/constants"
+	"github.com/flashbots/go-boost-utils/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
@@ -79,6 +81,41 @@ func TestGetProposerPayloadsDelivered(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, traces)
+			}
+		})
+	}
+}
+
+func TestGetValidatorRegistration(t *testing.T) {
+	publicKey := types.PublicKey{}
+	err := publicKey.UnmarshalText([]byte("0xb606e206c2bf3b78f53ebff8be8e8d4af2f0da68646b5642c4d511b15ab5ddb122ae57b48eab614f8ca5bafbe75a5999"))
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name          string
+		baseURL       string
+		publicKey     types.PublicKey
+		expectedError bool
+	}{
+		{
+			name:          "Validator",
+			baseURL:       constants.FlashbotsRelayMainnet,
+			publicKey:     publicKey,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := NewTransparencyClient(tt.baseURL, time.Second)
+
+			registration, err := clt.GetValidatorRegistration(tt.publicKey)
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, registration)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, registration)
 			}
 		})
 	}

--- a/data/client_test.go
+++ b/data/client_test.go
@@ -88,6 +88,7 @@ func TestGetProposerPayloadsDelivered(t *testing.T) {
 
 func TestGetValidatorRegistration(t *testing.T) {
 	publicKey := types.PublicKey{}
+	//nolint:lll
 	err := publicKey.UnmarshalText([]byte("0xb606e206c2bf3b78f53ebff8be8e8d4af2f0da68646b5642c4d511b15ab5ddb122ae57b48eab614f8ca5bafbe75a5999"))
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

This PR adds a new method in the Data Transparency Client to get the validator registration at endpoint `/relay/v1/data/validator_registration?pubkey=_pubkey_`.


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

