### PR TITLE
feat: add new method to get builder block received by relay

### DIFF
--- a/data/client_test.go
+++ b/data/client_test.go
@@ -127,3 +127,86 @@ func TestGetValidatorRegistration(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBuilderBlocksReceived(t *testing.T) {
+	testCases := []struct {
+		name          string
+		baseURL       string
+		options       *GetBuilderBlocksReceivedOptions
+		expectedError bool
+	}{
+		{
+			name:          "Invalid base URL",
+			baseURL:       "",
+			options:       nil,
+			expectedError: true,
+		},
+		/*
+			{
+				name:    "Invalid block hash",
+				baseURL: ropstenBaseURL,
+				options: &GetProposerPayloadsDeliveredOptions{
+					BlockHash: "",
+				},
+				expectedError: true,
+			},
+		*/
+		{
+			name:          "Valid request on Mainnet",
+			baseURL:       constants.FlashbotsRelayMainnet,
+			options:       nil,
+			expectedError: false,
+		},
+		{
+			name:    "Valid request on Mainnet with limit",
+			baseURL: constants.FlashbotsRelayMainnet,
+			options: &GetBuilderBlocksReceivedOptions{
+				Limit: 5,
+			},
+			expectedError: false,
+		},
+		{
+			name:          "Valid request on Kiln",
+			baseURL:       constants.FlashbotsRelayKiln,
+			options:       nil,
+			expectedError: false,
+		},
+		{
+			name:          "Valid request on Ropsten",
+			baseURL:       constants.FlashbotsRelayRopsten,
+			options:       nil,
+			expectedError: false,
+		},
+		{
+			name:          "Valid request on Sepolia",
+			baseURL:       constants.FlashbotsRelaySepolia,
+			options:       nil,
+			expectedError: false,
+		},
+		{
+			name:          "Valid request on Goerli",
+			baseURL:       constants.FlashbotsRelayGoerli,
+			options:       nil,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := NewTransparencyClient(tt.baseURL, time.Second)
+
+			traces, err := clt.GetBuilderBlocksReceived(tt.options)
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, traces)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, traces)
+
+				if tt.options != nil && tt.options.Limit > 0 {
+					assert.Len(t, traces, int(tt.options.Limit))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Luca Georges Francois <luca.georges-francois@kiln.fi>

## Description

This PR adds a new method to get the builder block received by the targetted relay.
Able to take filters to scope the request.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
